### PR TITLE
trello.api now supports args

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,10 @@ trello.params = function(args) {
   return str;
 };
 
-trello.api = function(apiCall, callback) {
+trello.api = function(apiCall, args, callback) {
+  callback = callback || args;
+  args = args || {};
+  
   var host = "trello.com";
   var options = {
     host: host,
@@ -26,7 +29,6 @@ trello.api = function(apiCall, callback) {
     method: 'GET'
   };
 
-  var args = {};
   if(trello.key) {
     args["key"] = trello.key;
   }

--- a/tests.js
+++ b/tests.js
@@ -14,6 +14,15 @@ var tests = {
       if(err) throw err;
       assert.ok(data.length > 0);
     });
+  },
+  getBoardsWithArgs: function() {
+    var args = { fields: "name,desc" };
+    trello.api("/1/organization/grinfo/boards/all", args, function(err, data) {
+      if(err) throw err;
+      assert.ok(data.length > 0);
+      // we asked for two fields, but id is always returned, so we look for 3
+      assert.equal(3, Object.keys(data[0]).length)
+    });
   }
 };
 


### PR DESCRIPTION
main.js always set args to {} before setting the key and token.

Now, you can pass an optional second parameter: args.

I updated the test to reflect this as well.

-Micah
