### PR TITLE
Update to backup example to backup lists and cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Node wrapper for Trello's HTTP API.
 
 * With these values [visit this other link](https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token) (Replacing, of course &lt;PUBLIC_KEY&gt; for the public key value obtained).
 
-* Authorice MyApp to read the application
+* Authorize MyApp to read the application
 
 * MyApp now have the token.
 

--- a/backup.js
+++ b/backup.js
@@ -57,25 +57,56 @@ trello_backup.prototype.writeCards = function(board_name, data) {
 trello_backup.prototype.createCSV = function(data) {
     var csv = "";
     //title
-    var card = data[0];
-    for(key in card) {
-        csv += key + ", ";
+    var list = data[0];
+    for(key in list) {
+			if (key != "cards") {
+				csv += key + ", ";
+			}   
     }
+		// ensure the card keys are always at the end
+		for(key2 in list.cards[0]) {
+			csv += key2 + ", ";					
+		}
     csv = csv.substr(0, csv.length-2);
     csv += '\n';
 
     //data
+		// builds the list csv piece and then prepends this to every card entry
     for (var i=0; i < data.length; i++) {
-        var card = data[i];
-        for(key in card) {
-            var prop = card[key].toString();
+        var list = data[i];
+				var list_csv = ""
+        for(key in list) {
+					if (key != "cards") {
+            var prop = list[key].toString();
             prop = prop.replace(/"/g,' '); // remove "
             prop = prop.replace(/,/g,' '); // remove ,
             prop = prop.replace(/\n/g, ' '); // remove new lines
-            csv += prop + ", ";
-        }
-        csv = csv.substr(0, csv.length-2);
-        csv += '\n';
+            list_csv += prop + ", ";
+					};
+        };
+
+				// make sure not to add an extra field
+        list_csv = list_csv.substr(0, list_csv.length-2);
+
+				// card data or dump list information if no cards
+				if (list.cards != null) {
+					for (var j=0; j < list.cards.length; j++) {
+						csv += list_csv + ",";
+						var card = list.cards[j]
+						for(key in card) {
+							var prop = card[key].toString();
+							prop = prop.replace(/"/g,' '); // remove "
+							prop = prop.replace(/,/g,' '); // remove ,
+							prop = prop.replace(/\n/g, ' '); // remove new lines
+							csv += prop + ", ";
+						};
+		        csv = csv.substr(0, csv.length-2);
+		        csv += '\n';
+					};      
+				} else {
+					csv += list_csv;
+	        csv += '\n';						
+				};
     };
     return csv;
 }

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,35 @@
+var Trello = require("./main.js");
+var fs = require('fs');
+
+var trello_backup = function(app_key, oauth_access_token, organization) {
+    this.organization = organization;
+    this.trello = new Trello(app_key, oauth_access_token);
+}
+
+trello_backup.prototype.backupOrganization = function() {
+    var self = this;
+    this.trello.get("/1/organization/" + this.organization + "/boards/all", function(err, data) {
+        if(err) throw err;
+        for (var i=0; i < data.length; i++) {
+            self.backupCards(data[i].id, data[i].name);
+        }
+    });
+}
+
+trello_backup.prototype.backupCards = function(board_id, board_name) {
+    this.trello.get('/1/board/' + board_id + '/cards/all', function(err, data) {
+        if(err) throw err;
+        var filename = board_name + " - " + new Date().toString()  + ".json";
+        console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
+
+        fs.writeFile(filename, JSON.stringify(data), function(err) {
+            if(err) {
+                console.log(err);
+            } else {
+                console.log("Saved to " + filename);
+            }
+        });
+    });
+}
+
+exports = module.exports = trello_backup;

--- a/backup.js
+++ b/backup.js
@@ -1,9 +1,10 @@
 var Trello = require("./main.js");
 var fs = require('fs');
 
-var trello_backup = function(app_key, oauth_access_token, organization) {
+var trello_backup = function(app_key, oauth_access_token, organization, data_type) {
     this.organization = organization;
     this.trello = new Trello(app_key, oauth_access_token);
+    this.data_type = data_type; //json, csv
 }
 
 trello_backup.prototype.backupOrganization = function() {
@@ -17,19 +18,57 @@ trello_backup.prototype.backupOrganization = function() {
 }
 
 trello_backup.prototype.backupCards = function(board_id, board_name) {
+    var self = this;
     this.trello.get('/1/board/' + board_id + '/cards/all', function(err, data) {
         if(err) throw err;
-        var filename = board_name + " - " + new Date().toString()  + ".json";
-        console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
-
-        fs.writeFile(filename, JSON.stringify(data), function(err) {
-            if(err) {
-                console.log(err);
-            } else {
-                console.log("Saved to " + filename);
-            }
-        });
+        self.writeCards(board_name, data);
     });
+}
+
+trello_backup.prototype.writeCards = function(board_name, data) {
+    var filename = board_name + " - " + new Date().toString()  + "." + this.data_type;
+    console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
+
+    var string;
+    if(this.data_type == 'csv') {
+        string = this.createCSV(data);
+    }else {
+        string = JSON.stringify(data);
+    }
+
+    fs.writeFile(filename, string, function(err) {
+        if(err) {
+            console.log(err);
+        } else {
+            console.log("Saved to " + filename);
+        }
+    });
+}
+
+trello_backup.prototype.createCSV = function(data) {
+    var csv = "";
+    //title
+    var card = data[0];
+    for(key in card) {
+        csv += key + ", ";
+    }
+    csv = csv.substr(0, csv.length-2);
+    csv += '\n';
+
+    //data
+    for (var i=0; i < data.length; i++) {
+        var card = data[i];
+        for(key in card) {
+            var prop = card[key].toString();
+            prop = prop.replace(/"/g,' '); // remove "
+            prop = prop.replace(/,/g,' '); // remove ,
+            prop = prop.replace(/\n/g, ' '); // remove new lines
+            csv += prop + ", ";
+        }
+        csv = csv.substr(0, csv.length-2);
+        csv += '\n';
+    };
+    return csv;
 }
 
 exports = module.exports = trello_backup;

--- a/example_backup.js
+++ b/example_backup.js
@@ -1,11 +1,13 @@
 var TrelloBackup = require("./backup.js");
 
+
 //config
 var app_key = '<app_key>';
 var oauth_access_token = '<oauth_access_token>';
 var organization = '<organization>';
+var data_type = 'csv'; //json, csv
 
 //usage
-var tb = new TrelloBackup(app_key, oauth_access_token, organization);
+var tb = new TrelloBackup(app_key, oauth_access_token, organization, data_type);
 tb.backupOrganization();
 

--- a/example_backup.js
+++ b/example_backup.js
@@ -7,22 +7,24 @@ var Trello = require("./main.js");
 var t = new Trello(app_key, oauth_access_token);
 
 t.get("/1/organization/" + organization + "/boards/all", function(err, data) {
-  if(err) throw err;
-  for(board in data) {
-      var board_id = data[board].id;
-      var board_name = data[board].name;
-      t.api('/1/board/' + board_id + '/cards/all', function(err, data) {
-          if(err) throw err;
-          var filename = board_name + " - " + new Date().toString()  + ".json";
-          console.log('Backing up ' + data.length + ' cards for board "' + board_name);
-          
-          fs.writeFile(filename, JSON.stringify(data), function(err) {
-              if(err) {
-                  console.log(err);
-              } else {
-                  console.log("Saved to " + filename);
-              }
-          });
-      });
-  }
+    if(err) throw err;
+    for (var i=0; i < data.length; i++) {
+        backupLists(data[i].id, data[i].name);
+    }
 });
+
+function backupLists(board_id, board_name) {
+    t.get('/1/board/' + board_id + '/lists/all', function(err, data) {
+        if(err) throw err;
+        var filename = board_name + " - " + new Date().toString() + ".json";
+        console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
+
+        fs.writeFile(filename, JSON.stringify(data), function(err) {
+            if(err) {
+                console.log(err);
+            } else {
+                console.log("Saved to " + filename);
+            }
+        });
+    });
+}

--- a/example_backup.js
+++ b/example_backup.js
@@ -1,21 +1,23 @@
-var app_key = <app_key>;
-var oauth_access_token = <oauth_access_token>;
-var organization = <organization>;
-
-
-var fs = require('fs');
 var Trello = require("./main.js");
-var t = new Trello(app_key, oauth_access_token);
+var fs = require('fs');
 
-t.get("/1/organization/" + organization + "/boards/all", function(err, data) {
-    if(err) throw err;
-    for (var i=0; i < data.length; i++) {
-        backupCards(data[i].id, data[i].name);
-    }
-});
+var trello_backup = function(app_key, oauth_access_token, organization) {
+    this.organization = organization;
+    this.trello = new Trello(app_key, oauth_access_token);
+}
 
-function backupCards(board_id, board_name) {
-    t.get('/1/board/' + board_id + '/cards/all', function(err, data) {
+trello_backup.prototype.backupOrganization = function() {
+    var self = this;
+    this.trello.get("/1/organization/" + this.organization + "/boards/all", function(err, data) {
+        if(err) throw err;
+        for (var i=0; i < data.length; i++) {
+            self.backupCards(data[i].id, data[i].name);
+        }
+    });
+}
+
+trello_backup.prototype.backupCards = function(board_id, board_name) {
+    this.trello.get('/1/board/' + board_id + '/cards/all', function(err, data) {
         if(err) throw err;
         var filename = board_name + " - " + new Date().toString()  + ".json";
         console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
@@ -29,3 +31,15 @@ function backupCards(board_id, board_name) {
         });
     });
 }
+
+exports = module.exports = trello_backup;
+
+//config
+var app_key = '<app_key>';
+var oauth_access_token = '<oauth_access_token>';
+var organization = '<organization>';
+
+//usage
+var tb = new trello_backup(app_key, oauth_access_token, organization);
+tb.backupOrganization();
+

--- a/example_backup.js
+++ b/example_backup.js
@@ -1,38 +1,4 @@
-var Trello = require("./main.js");
-var fs = require('fs');
-
-var trello_backup = function(app_key, oauth_access_token, organization) {
-    this.organization = organization;
-    this.trello = new Trello(app_key, oauth_access_token);
-}
-
-trello_backup.prototype.backupOrganization = function() {
-    var self = this;
-    this.trello.get("/1/organization/" + this.organization + "/boards/all", function(err, data) {
-        if(err) throw err;
-        for (var i=0; i < data.length; i++) {
-            self.backupCards(data[i].id, data[i].name);
-        }
-    });
-}
-
-trello_backup.prototype.backupCards = function(board_id, board_name) {
-    this.trello.get('/1/board/' + board_id + '/cards/all', function(err, data) {
-        if(err) throw err;
-        var filename = board_name + " - " + new Date().toString()  + ".json";
-        console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
-
-        fs.writeFile(filename, JSON.stringify(data), function(err) {
-            if(err) {
-                console.log(err);
-            } else {
-                console.log("Saved to " + filename);
-            }
-        });
-    });
-}
-
-exports = module.exports = trello_backup;
+var TrelloBackup = require("./backup.js");
 
 //config
 var app_key = '<app_key>';
@@ -40,6 +6,6 @@ var oauth_access_token = '<oauth_access_token>';
 var organization = '<organization>';
 
 //usage
-var tb = new trello_backup(app_key, oauth_access_token, organization);
+var tb = new TrelloBackup(app_key, oauth_access_token, organization);
 tb.backupOrganization();
 

--- a/example_backup.js
+++ b/example_backup.js
@@ -1,28 +1,31 @@
-var app_key = '<app_key>';
-var oauth_access_token = '<oauth_access_token>';
-var organization = '<organization>';
+var app_key = <app_key>;
+var oauth_access_token = <oauth_access_token>;
+var organization = <organization>;
+
 
 var fs = require('fs');
 var Trello = require("./main.js");
 var t = new Trello(app_key, oauth_access_token);
 
 t.api("/1/organization/" + organization + "/boards/all", function(err, data) {
-  if(err) throw err;
-  for(board in data) {
-      var board_id = data[board].id;
-      var board_name = data[board].name;
-      t.api('/1/board/' + board_id + '/cards/all', function(err, data) {
-          if(err) throw err;
-          var filename = board_name + " - " + new Date().toString()  + ".json";
-          console.log('Backing up ' + data.length + ' cards for board "' + board_name);
-          
-          fs.writeFile(filename, JSON.stringify(data), function(err) {
-              if(err) {
-                  console.log(err);
-              } else {
-                  console.log("Saved to " + filename);
-              }
-          });
-      });
-  }
+    if(err) throw err;
+    for (var i=0; i < data.length; i++) {
+        backupCards(data[i].id, data[i].name);
+    }
 });
+
+function backupCards(board_id, board_name) {
+    t.api('/1/board/' + board_id + '/cards/all', function(err, data) {
+        if(err) throw err;
+        var filename = board_name + " - " + new Date().toString()  + ".json";
+        console.log('Backing up ' + data.length + ' cards for board "' + board_name + '"');
+
+        fs.writeFile(filename, JSON.stringify(data), function(err) {
+            if(err) {
+                console.log(err);
+            } else {
+                console.log("Saved to " + filename);
+            }
+        });
+    });
+}


### PR DESCRIPTION
This copies heavily from the revised code from @adcloud => @luebken to correct the problem with multiple board backup corrupting the base filename and overwriting backups.  

Changes API call to leverage lists which will also dump all open card information by default, current example will lose detail on List names/information.
