### PR TITLE
Make it compatible with node 0.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   }
 , "bugs" :
   { "url" : "http://github.com/lmatteis/node-trello/issues" }
-, "engines" : ["node >= 0.6.6"]
+, "engines" : ["node >= 0.4.7"]
 , "main" : "./main"
 ,"scripts": { "test": "node tests.js" }
 }


### PR DESCRIPTION
I would like to use node-trello on heroku. After few tests, node-trello works file with node 0.4.
