### PR TITLE
Add support for POST and PUT operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Node wrapper for Trello's HTTP API.
 * Public Key & Secret: [visit this link while logged in Trello](https://trello.com/1/appKey/generate).
 
 * With these values [visit this other link](https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token) (Replacing, of course &lt;PUBLIC_KEY&gt; for the public key value obtained).
+** If you need read/write access, add the following to the end of the prior URL:  &scope=read,write
 
 * Authorice MyApp to read the application
 

--- a/main.js
+++ b/main.js
@@ -11,9 +11,8 @@ trello.prototype.get = trello.prototype.api = function(apiCall, args, callback) 
   callback = callback || args;
   args = args || {};
   
-  var host = "api.trello.com";
   var options = {
-    host: host,
+    host: this.host,
     port: 443,
     path: apiCall,
     method: 'GET'

--- a/main.js
+++ b/main.js
@@ -1,22 +1,10 @@
 var https = require('https');
+var querystring = require('querystring');
 
 var trello = function(key, token) {
   this.key = key;
   this.token = token;
   this.host = "api.trello.com";
-};
-
-trello.prototype.params = function(args) {
-  var str = "";
-  var c = 1;
-  for(var i in args) {
-    if (c == 1)
-      c = 0;
-    else
-      str += "&";
-    str += i + "=" + args[i];
-  }
-  return str;
 };
 
 trello.prototype.get = trello.prototype.api = function(apiCall, args, callback) {
@@ -38,7 +26,7 @@ trello.prototype.get = trello.prototype.api = function(apiCall, args, callback) 
     args["token"] = this.token;
   }
 
-  options.path += "?" + this.params(args);
+  options.path += "?" + querystring.stringify(args);
   var req = https.request(options, function(res) {
     res.setEncoding('utf8');
     var data = "";


### PR DESCRIPTION
I've added support for POST and PUT operations so that you can modify or create new objects on Trello.  I've tested it with creating a new Card in one of my Boards.

My commits also includes a change to use the built-in querystring.stringify() method that is shipped with Node.JS, in order to prevent problems with unsafe characters not being properly escaped.  This becomes more of a problem when you start using the POST/PUT operations with descriptions and names that can have any manner of characters in them.  http://nodejs.org/docs/v0.3.1/api/querystring.html

I also noticed that you didn't seem to be using the this.host variable that was already defined, so I cleaned it up to use that instead of repeating the hostname in the code again.
