### PR TITLE
Correcting Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Node wrapper for Trello's HTTP API.
 * With these values [visit this other link](https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token) (Replacing, of course &lt;PUBLIC_KEY&gt; for the public key value obtained).
 ** If you need read/write access, add the following to the end of the prior URL:  &scope=read,write
 
-* Authorice MyApp to read the application
+* Authorize MyApp to read the application
 
 * MyApp now have the token.
 


### PR DESCRIPTION
I made on quick typo fix on the Readme page "Authorize" vs "Authorice"
