### PR TITLE
Support for arguments passed as query string parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Node wrapper for Trello's HTTP API.
 * With these values [visit this other link](https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token) (Replacing, of course &lt;PUBLIC_KEY&gt; for the public key value obtained).
 ** If you need read/write access, add the following to the end of the prior URL:  &scope=read,write
 
-* Authorice MyApp to read the application
+* Authorize MyApp to read the application
 
 * MyApp now have the token.
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
-Node wrapper for Trello's HTTP API.
-====
+# Node wrapper for Trello’s HTTP API.
+[View Trello’s API documentation online][apidocs]. For information on Trello’s API development, visit [their Trello board][trellotrello], of course.
+
+[apidocs]: https://trello.com/docs/
+[trellotrello]: https://trello.com/board/trello-public-api/4ed7e27fe6abb2517a21383d
 
 ## Install
+```
+npm install node-trello
+```
 
-    npm install node-trello
+### Getting your key and token
+* [Generate your developer key][devkey] and supply it as the first constructor parameter.
+* To read a user’s private information, get a token by directing them to `https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token` replacing, of course, &lt;PUBLIC_KEY&gt; with the public key obtained in the first step.
+* If you need write access as well as read, `&scope=read,write` to the request for your user token.
 
-### Getting the Token
+[devkey]: https://trello.com/1/appKey/generate
 
-* Public Key & Secret: [visit this link while logged in Trello](https://trello.com/1/appKey/generate).
-
-* With these values [visit this other link](https://trello.com/1/connect?key=<PUBLIC_KEY>&name=MyApp&response_type=token) (Replacing, of course &lt;PUBLIC_KEY&gt; for the public key value obtained).
-** If you need read/write access, add the following to the end of the prior URL:  &scope=read,write
-
-* Authorize MyApp to read the application
-
-* MyApp now have the token.
-
-### Example Code
-
-````javascript
+## Example Code
+```javascript
 var Trello = require("node-trello");
-
 var t = new Trello("<your key>", "<token>");
 
-t.get("/1/organization/some-org/boards/all", function(err, data) {
-  if(err) throw err;
+t.get("/1/members/me", function(err, data) {
+  if (err) throw err;
   console.log(data);
 });
+```

--- a/main.js
+++ b/main.js
@@ -30,6 +30,17 @@ trello.prototype.invokeGeneric = function(method, apiCall, args, callback) {
     args["token"] = this.token;
   }
   if (method == 'GET') {
+    if (options.path.indexOf("?") != -1) {
+      var parts = options.path.split("?");
+      var additionalArgs = parts[1];
+
+      options.path = parts[0];
+
+      for (var argName in additionalArgs) {
+        args[argName] = additionalArgs[argName];
+      }
+    }
+    
     options.path += "?" + querystring.stringify(args);
   } else {
     post_data = querystring.stringify(args);

--- a/package.json
+++ b/package.json
@@ -1,16 +1,25 @@
 {
-  "name" : "node-trello"
-, "description" : "Node wrapper for Trello's HTTP API."
-, "tags" : ["http", "trello", "api", "web-service"]
-, "version" : "0.0.1"
-, "author" : "Luca Matteis <lmatteis@gmail.com>"
-, "repository" :
-  { "type" : "git"
-  , "url" : "http://github.com/lmatteis/node-trello.git"
+  "name" : "node-trello", 
+  "description" : "Node wrapper for Trello's HTTP API.", 
+  "tags" : ["http", "trello", "api", "web-service"], 
+  "version" : "0.0.2", 
+  "author" : "Luca Matteis <lmatteis@gmail.com>",
+  "contributors": [
+    {
+      "name": "Andrew Dunkman",
+      "email": "andrew@dunkman.org"
+    }
+  ], 
+  "repository" : { 
+    "type" : "git", 
+    "url" : "http://github.com/adunkman/node-trello.git"
+  }, 
+  "bugs" : { 
+      "url" : "http://github.com/adunkman/node-trello/issues" 
+  }, 
+  "engines" : [ "node >= 0.4.7" ], 
+  "main" : "./main",
+  "scripts": { 
+    "test": "node tests.js" 
   }
-, "bugs" :
-  { "url" : "http://github.com/lmatteis/node-trello/issues" }
-, "engines" : ["node >= 0.4.7"]
-, "main" : "./main"
-,"scripts": { "test": "node tests.js" }
 }


### PR DESCRIPTION
I added support for arguments in the URL, for example: 

/1/boards/{board}/cards?filter=all
